### PR TITLE
fix: 修改 ClassExpression 的语法树解析方式，方便引入 decorator 的滋瓷

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,49 +19,46 @@ reactJsxTransformPlugin["default"] = function (_ref) {
 }
 
 // Fixed Class
-var classPropertiresTransformPlugin = require('babel-plugin-transform-class-properties');
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
 var buildWeactClass = require("babel-template")(`
   CLASS_NAME = RNPlus ? RNPlus.register(CLASS_NAME, CLASS_NAME_STR, IS_INNER) : CLASS_NAME;
 `);
 
-classPropertiresTransformPlugin.__esModule = true;
-classPropertiresTransformPlugin["default"] = function (_ref) {
+module.exports = function(babel) {
     var VISITED = _Symbol();
-    var t = _ref.types;
-    var res = classPropertiresTransformPlugin(_ref);
-    var ClassFn = res.visitor.Class;
+    var t = babel.types;
 
-    res.visitor.Class = function (path, state) {
-        var node = path.node;
+    var visitor = {
+        ClassDeclaration: function(path) {
+            var node = path.node;
 
-        if (node.id && !node[VISITED]) {
-            var name = node.id.name;
-            var superClass = node.superClass;
+            if (node.id && !node[VISITED]) {
+                var name = node.id.name;
+                var superClass = node.superClass;
 
-            if (superClass && superClass.name) {
-                var superClassName = superClass.name;
+                if (superClass && superClass.name) {
+                    var superClassName = superClass.name;
 
-                if (superClassName  === 'PView' || superClassName === 'PComponent') {
-                    path.insertAfter(buildWeactClass({
-                        CLASS_NAME: t.identifier(name),
-                        CLASS_NAME_STR: t.stringLiteral(name),
-                        IS_INNER: t.booleanLiteral(false)
-                    }));
-                } else if (superClassName === '__PView' || superClassName === '__PComponent') {
-                    path.insertAfter(buildWeactClass({
-                        CLASS_NAME: t.identifier(name),
-                        CLASS_NAME_STR: t.stringLiteral(name),
-                        IS_INNER: t.booleanLiteral(true)
-                    }));
+                    if (superClassName  === 'PView' || superClassName === 'PComponent') {
+                        path.insertAfter(buildWeactClass({
+                            CLASS_NAME: t.identifier(name),
+                            CLASS_NAME_STR: t.stringLiteral(name),
+                            IS_INNER: t.booleanLiteral(false)
+                        }));
+                    } else if (superClassName === '__PView' || superClassName === '__PComponent') {
+                        path.insertAfter(buildWeactClass({
+                            CLASS_NAME: t.identifier(name),
+                            CLASS_NAME_STR: t.stringLiteral(name),
+                            IS_INNER: t.booleanLiteral(true)
+                        }));
+                    }
                 }
+                node[VISITED] = true;
             }
-            node[VISITED] = true;
         }
-
-        ClassFn(path, state);
     };
-    return res;
-}
 
-module.exports = {};
+    return {
+        visitor: visitor
+    }
+};


### PR DESCRIPTION
原来的 plugin 粗暴的修改了 `babel-plugin-transform-class-properties` 的 visitor，搞得别的操作 Class 的插件搞不了，现在按照 babel 的指定的爬语法树的规则来搞，就能滋瓷 decorator 啦。

