### PR TITLE
add context to super call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,8 @@ module.exports = function(babel) {
                     }
                 }
 
-                path.traverse(subVisitor);
+                if(node.superClass && t.isIdentifier(node.superClass) && node.superClass.name === 'PComponent')
+                    path.traverse(subVisitor);
 
                 node[VISITED] = true;
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 // Fixed ReactJSX
 var reactJsxTransformPlugin = require('babel-plugin-transform-react-jsx');
 var parse = require("babylon").parse;
+var template = require("babel-template");
 
 reactJsxTransformPlugin.__esModule = true;
 reactJsxTransformPlugin["default"] = function (_ref) {
@@ -20,13 +21,27 @@ reactJsxTransformPlugin["default"] = function (_ref) {
 
 // Fixed Class
 var _Symbol = require("babel-runtime/core-js/symbol")["default"];
-var buildWeactClass = require("babel-template")(`
+var buildWeactClass = template(`
   CLASS_NAME = RNPlus ? RNPlus.register(CLASS_NAME, CLASS_NAME_STR, IS_INNER) : CLASS_NAME;
+`);
+var buildSuperApply = template(`
+  super(...arguments);
 `);
 
 module.exports = function(babel) {
     var VISITED = _Symbol();
     var t = babel.types;
+
+    var subVisitor = {
+        CallExpression(path) {
+            var node = path.node;
+
+            if(!t.isSuper(node.callee)) return;
+            if(node.arguments.length===1 && t.isSpreadElement(node.arguments[0])) return;
+
+            path.replaceWith(buildSuperApply());
+        }
+    };
 
     var visitor = {
         ClassDeclaration: function(path) {
@@ -53,9 +68,12 @@ module.exports = function(babel) {
                         }));
                     }
                 }
+
+                path.traverse(subVisitor);
+
                 node[VISITED] = true;
             }
-        }
+        },
     };
 
     return {


### PR DESCRIPTION
在添加了PComponent能够接受PView中的actived等页面级事件后，需要在PComponent中的constructor中的super调用里将接收到的context传给基类constructor，为此，添加了Babel功能，将所有的super调用语句改为super(...arguments)的形式